### PR TITLE
Add macOS notification when notes are generated

### DIFF
--- a/meeting2notes/cli.py
+++ b/meeting2notes/cli.py
@@ -188,6 +188,9 @@ def main() -> None:
     else:
         print(f"Saved notes to: {out_path}")
 
+    # Send notification
+    utils.send_notification("Meeting2Notes", f"Notes ready: {meeting_title}")
+
 
 if __name__ == "__main__":
     main()

--- a/meeting2notes/utils.py
+++ b/meeting2notes/utils.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import datetime as dt
 import re
+import subprocess
+import sys
 
 
 def iso_timestamp_local() -> str:
@@ -24,3 +26,23 @@ def markdown_to_text(md: str) -> str:
     text = re.sub(r"- \[ \]\s*", "- ", text)
     text = re.sub(r"^-{3,}$", "", text, flags=re.MULTILINE)
     return text.strip()
+
+
+def send_notification(title: str, message: str = "", sound: bool = True) -> None:
+    """Send a macOS notification. Fails silently on other platforms."""
+    if sys.platform != "darwin":
+        return
+
+    script = f'display notification "{message}" with title "{title}"'
+    if sound:
+        script += ' sound name "Glass"'
+
+    try:
+        subprocess.run(
+            ["osascript", "-e", script],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except FileNotFoundError:
+        pass  # osascript not available


### PR DESCRIPTION
## Summary

- Adds `send_notification()` utility function to `utils.py`
- CLI now sends a macOS notification with sound when notes are ready
- Uses native `osascript` - no additional dependencies
- Fails silently on non-macOS platforms

## Test plan

- [ ] Run CLI with `./run.sh --audio <file>`
- [ ] Verify macOS notification appears when notes are saved
- [ ] Verify notification includes meeting title

Closes #8

🤖 Generated with [Claude Code](https://claude.ai/code)